### PR TITLE
Add time-weighted numeric baselines and tests

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -37,6 +37,10 @@ MAX_RETRIES = 3  # Maximum number of retry attempts for API calls
 # Data Processing Settings
 MIN_SAMPLE_SIZE = 15  # Minimum sample size for statistical analysis
 
+# Numeric baseline weighting configuration
+TIME_WEIGHTING_ENABLED = True  # Prioritise recent projects in baseline stats
+TIME_WEIGHTING_HALF_LIFE_DAYS = 730  # Two-year half-life for exponential decay
+
 # Project directories
 PROJECT_ROOT = Path(__file__).parent.parent
 DATA_DIR = PROJECT_ROOT / "data"

--- a/src/core/numeric_analyzer.py
+++ b/src/core/numeric_analyzer.py
@@ -26,6 +26,17 @@ except ImportError:
         PipelineStage
     )
 
+try:
+    from .. import config as _config  # type: ignore
+except ImportError:  # pragma: no cover - fallback for direct execution
+    try:
+        import src.config as _config  # type: ignore
+    except ImportError:  # pragma: no cover - ultimate fallback
+        _config = None  # type: ignore
+
+TIME_WEIGHTING_ENABLED = getattr(_config, "TIME_WEIGHTING_ENABLED", True)
+TIME_WEIGHTING_HALF_LIFE_DAYS = getattr(_config, "TIME_WEIGHTING_HALF_LIFE_DAYS", 730)
+
 logger = logging.getLogger(__name__)
 
 
@@ -37,6 +48,8 @@ class NumericBaseline:
     def __init__(self, lookback_days: Optional[int] = None):
         self.smoothing_k = 1.0  # Laplace smoothing parameter
         self.lookback_days = lookback_days or 1825 # Default to 5 years
+        self.time_weighting_enabled = TIME_WEIGHTING_ENABLED
+        self.time_weighting_half_life_days = TIME_WEIGHTING_HALF_LIFE_DAYS
         logger.info(f"NumericBaseline initialized with {self.lookback_days} days ({self.lookback_days/365:.1f} years) lookback")
 
     def _piecewise_scale(self, x: Optional[float], points: List[Tuple[float, float]]) -> float:
@@ -60,6 +73,48 @@ class NumericBaseline:
                 t = (x - x0) / (x1 - x0)
                 return float(y0 + t * (y1 - y0))
         return float(pts[-1][1])
+
+    def _calculate_time_weights(
+        self,
+        dates: pd.Series,
+        half_life_days: float = 730.0
+    ) -> pd.Series:
+        """Generate exponential decay weights that favour recent projects.
+
+        Rows with missing or invalid ``date_created`` values are assigned the
+        minimum observed weight so they still contribute while preventing NaNs
+        from propagating through weighted statistics.
+        """
+        if dates is None or dates.empty:
+            return pd.Series(dtype=float)
+
+        half_life_days = max(float(half_life_days or 1.0), 1.0)
+
+        dt_series = pd.to_datetime(dates, errors='coerce')
+        valid_mask = dt_series.notna()
+
+        if not valid_mask.any():
+            return pd.Series(1.0, index=dates.index, dtype=float)
+
+        reference_date = pd.Timestamp.now(tz=dt_series.dt.tz)
+        days_ago = (reference_date - dt_series[valid_mask]).dt.total_seconds() / 86400.0
+        days_ago = np.maximum(days_ago, 0.0)
+
+        valid_weights = np.power(0.5, days_ago / half_life_days)
+        weights = pd.Series(0.0, index=dates.index, dtype=float)
+        weights.loc[valid_mask] = valid_weights
+
+        if (~valid_mask).any():
+            min_weight = float(valid_weights.min()) if len(valid_weights) else 1.0
+            weights.loc[~valid_mask] = min_weight
+
+        total_weight = float(weights.sum())
+        if total_weight <= 0:
+            weights.loc[:] = 1.0
+        else:
+            weights *= len(weights) / total_weight
+
+        return weights
     
     def _compute_global_closed_prior(self, df: pd.DataFrame) -> Tuple[Optional[float], int]:
         if df is None or df.empty:
@@ -81,7 +136,7 @@ class NumericBaseline:
             return float(won) / total, total
         return None, 0
 
-    def _beta_smoothed_rate(self, won: int, lost: int, prior_rate: Optional[float], prior_strength: Optional[int]) -> float:
+    def _beta_smoothed_rate(self, won: float, lost: float, prior_rate: Optional[float], prior_strength: Optional[int]) -> float:
         if prior_rate is not None and prior_strength and prior_strength > 0:
             alpha = prior_rate * prior_strength
             beta = (1.0 - prior_rate) * prior_strength
@@ -91,8 +146,10 @@ class NumericBaseline:
         return float(won + k) / float((won + lost) + 2 * k)
 
     def calculate_gestation_baseline(
-        self, 
-        segment_data: pd.DataFrame
+        self,
+        segment_data: pd.DataFrame,
+        apply_time_weighting: Optional[bool] = None,
+        half_life_days: Optional[float] = None
     ) -> Tuple[Optional[int], Dict[str, Any]]:
         """
         Calculate expected gestation period using median with IQR
@@ -117,42 +174,74 @@ class NumericBaseline:
                 'sample_size': len(gestation_values)
             }
         
-        # Calculate statistics
-        median_val = gestation_values.median()
-        p25 = gestation_values.quantile(0.25)
-        p75 = gestation_values.quantile(0.75)
+        use_weighting = self.time_weighting_enabled if apply_time_weighting is None else bool(apply_time_weighting)
+        weight_half_life = half_life_days if half_life_days is not None else self.time_weighting_half_life_days
+
+        weighting_note = "unweighted"
+        mean_val = float(gestation_values.mean())
+        std_val = float(gestation_values.std())
+        median_val = float(gestation_values.median())
+        p25 = float(gestation_values.quantile(0.25))
+        p75 = float(gestation_values.quantile(0.75))
+
+        if use_weighting and 'date_created' in segment_data.columns:
+            weights = self._calculate_time_weights(
+                segment_data.loc[gestation_values.index, 'date_created'],
+                half_life_days=weight_half_life
+            )
+            weights = weights.reindex(gestation_values.index).fillna(0.0)
+            if not weights.empty and float(weights.sum()) > 0:
+                sorted_idx = gestation_values.sort_values().index
+                sorted_values = gestation_values.loc[sorted_idx].to_numpy(dtype=float)
+                sorted_weights = weights.loc[sorted_idx].to_numpy(dtype=float)
+                cumulative = np.cumsum(sorted_weights)
+                if cumulative[-1] > 0:
+                    cumulative /= cumulative[-1]
+                    median_val = float(np.interp(0.5, cumulative, sorted_values))
+                    p25 = float(np.interp(0.25, cumulative, sorted_values))
+                    p75 = float(np.interp(0.75, cumulative, sorted_values))
+                    mean_val = float(np.average(sorted_values, weights=sorted_weights))
+                    variance = float(np.average((sorted_values - mean_val) ** 2, weights=sorted_weights))
+                    std_val = float(np.sqrt(max(variance, 0.0)))
+                    weighting_note = f"time_weighted_half_life_{int(weight_half_life)}d"
+
         iqr = p75 - p25
-        
+
         # Calculate confidence based on sample size and spread
         sample_confidence = min(len(gestation_values) / 30, 1.0)
-        
+
         # Penalize high variance
-        cv = gestation_values.std() / gestation_values.mean() if gestation_values.mean() > 0 else 1
+        cv = std_val / mean_val if mean_val > 0 else 1
         spread_confidence = max(0, 1 - cv)
-        
+
         overall_confidence = sample_confidence * 0.7 + spread_confidence * 0.3
-        
+
         statistics = {
-            'median': int(median_val),
-            'p25': int(p25),
-            'p75': int(p75),
-            'iqr': int(iqr),
-            'mean': int(gestation_values.mean()),
-            'std': int(gestation_values.std()),
+            'median': int(round(median_val)),
+            'p25': int(round(p25)),
+            'p75': int(round(p75)),
+            'iqr': int(round(iqr)),
+            'mean': int(round(mean_val)),
+            'std': int(round(std_val)),
             'count': len(gestation_values),
-            'confidence': round(overall_confidence, 2)
+            'confidence': round(overall_confidence, 2),
+            'weighting': weighting_note
         }
-        
-        logger.info(f"Gestation baseline: {int(median_val)} days (n={len(gestation_values)})")
-        
-        return int(median_val), statistics
+
+        logger.info(
+            f"Gestation baseline: {int(round(median_val))} days (n={len(gestation_values)}, {weighting_note})"
+        )
+
+        return int(round(median_val)), statistics
     
     def calculate_conversion_rate(
-        self, 
-        segment_data: pd.DataFrame, 
+        self,
+        segment_data: pd.DataFrame,
         method: str = 'inclusive',
         prior_rate: Optional[float] = None,
-        prior_strength: Optional[int] = None
+        prior_strength: Optional[int] = None,
+        apply_time_weighting: Optional[bool] = None,
+        half_life_days: Optional[float] = None
     ) -> Tuple[float, Dict[str, Any]]:
         if segment_data.empty:
             return 0.5, {'confidence': 0}
@@ -162,15 +251,46 @@ class NumericBaseline:
 
         if use_pipeline:
             stages = segment_data['pipeline_stage'].fillna('')
-            won_closed = int((stages == PipelineStage.WON_CLOSED.value).sum())
-            lost = int((stages == PipelineStage.LOST.value).sum())
+            won_mask = stages == PipelineStage.WON_CLOSED.value
+            lost_mask = stages == PipelineStage.LOST.value
         else:
             # Fallback: treat 'Won' as closed-won if pipeline_stage missing
-            sc = segment_data['status_category'] if 'status_category' in segment_data.columns else pd.Series([], dtype=object)
-            won_closed = int((sc == StatusCategory.WON.value).sum())
-            lost = int((sc == StatusCategory.LOST.value).sum())
+            sc = segment_data['status_category'] if 'status_category' in segment_data.columns else pd.Series(index=segment_data.index, dtype=object)
+            won_mask = sc == StatusCategory.WON.value
+            lost_mask = sc == StatusCategory.LOST.value
 
-        open_count = int(total - won_closed - lost)
+        open_mask = ~(won_mask | lost_mask)
+
+        won_closed = int(won_mask.sum())
+        lost = int(lost_mask.sum())
+        open_count = int(open_mask.sum())
+
+        use_weighting = self.time_weighting_enabled if apply_time_weighting is None else bool(apply_time_weighting)
+        weight_half_life = half_life_days if half_life_days is not None else self.time_weighting_half_life_days
+
+        weights = None
+        weighting_note = "unweighted"
+        if use_weighting and 'date_created' in segment_data.columns:
+            weights = self._calculate_time_weights(
+                segment_data['date_created'],
+                half_life_days=weight_half_life
+            )
+            weights = weights.reindex(segment_data.index).fillna(0.0)
+            if weights.empty or float(weights.sum()) <= 0:
+                weights = None
+            else:
+                weighting_note = f"time_weighted_half_life_{int(weight_half_life)}d"
+
+        if weights is not None:
+            won_closed_weighted = float(weights[won_mask].sum())
+            lost_weighted = float(weights[lost_mask].sum())
+            open_weighted = float(weights[open_mask].sum())
+            total_weighted = float(weights.sum())
+        else:
+            won_closed_weighted = float(won_closed)
+            lost_weighted = float(lost)
+            open_weighted = float(open_count)
+            total_weighted = float(total)
 
         if method == 'closed_only':
             total_closed = won_closed + lost
@@ -181,35 +301,49 @@ class NumericBaseline:
                     'losses': lost,
                     'open': open_count,
                     'note': 'No closed projects in segment',
-                    'method': 'closed_only'
+                    'method': 'closed_only',
+                    'weighting': weighting_note
                 }
-            rate = self._beta_smoothed_rate(won_closed, lost, prior_rate, prior_strength)
-            confidence = min(total_closed / 100, 1.0)
+            total_closed_weighted = won_closed_weighted + lost_weighted
+            if total_closed_weighted <= 0:
+                total_closed_weighted = float(total_closed)
+            rate = self._beta_smoothed_rate(won_closed_weighted, lost_weighted, prior_rate, prior_strength)
+            confidence = min(total_closed_weighted / 100, 1.0)
             statistics = {
                 'wins': won_closed,
                 'losses': lost,
                 'open': open_count,
                 'total': int(total_closed),
-                'raw_rate': (won_closed / total_closed) if total_closed > 0 else 0.0,
+                'raw_rate': (won_closed_weighted / total_closed_weighted) if total_closed_weighted > 0 else 0.0,
                 'smoothed_rate': rate,
                 'confidence': round(confidence, 2),
-                'method': 'closed_only'
+                'method': 'closed_only',
+                'wins_weighted': round(won_closed_weighted, 2),
+                'losses_weighted': round(lost_weighted, 2),
+                'total_weighted': round(total_closed_weighted, 2),
+                'weighting': weighting_note
             }
             return rate, statistics
         else:
             # Inclusive: won_closed / (won_closed + lost + open)
             k = self.smoothing_k
-            rate = float(won_closed + k) / float(total + 2 * k)
-            confidence = min(total / 100, 1.0)
+            denominator = total_weighted + 2 * k
+            rate = float(won_closed_weighted + k) / float(denominator) if denominator > 0 else 0.5
+            confidence = min(total_weighted / 100, 1.0)
             statistics = {
                 'wins': won_closed,
                 'losses': lost,
                 'open': open_count,
                 'total': int(total),
-                'raw_rate': (won_closed / total) if total > 0 else 0.0,
+                'raw_rate': (won_closed_weighted / total_weighted) if total_weighted > 0 else 0.0,
                 'smoothed_rate': rate,
                 'confidence': round(confidence, 2),
-                'method': 'inclusive_closed_wins'
+                'method': 'inclusive_closed_wins',
+                'wins_weighted': round(won_closed_weighted, 2),
+                'losses_weighted': round(lost_weighted, 2),
+                'open_weighted': round(open_weighted, 2),
+                'total_weighted': round(total_weighted, 2),
+                'weighting': weighting_note
             }
             return rate, statistics
     

--- a/tests/test_numeric_analyzer.py
+++ b/tests/test_numeric_analyzer.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+import sys
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.core.numeric_analyzer import NumericBaseline
+from src.core.models import PipelineStage, StatusCategory
+
+
+def _recent(days: int) -> pd.Timestamp:
+    return pd.Timestamp.now() - pd.Timedelta(days=days)
+
+
+def test_gestation_weighting_handles_missing_dates():
+    nb = NumericBaseline()
+    df = pd.DataFrame(
+        {
+            'gestation_period': [45, 60, 75, 90],
+            'date_created': [
+                _recent(10),
+                _recent(200),
+                None,
+                _recent(900),
+            ],
+        }
+    )
+
+    median, stats = nb.calculate_gestation_baseline(df)
+
+    assert median is not None
+    assert stats['count'] == 4
+    assert stats['weighting'].startswith('time_weighted')
+
+
+def test_conversion_rate_includes_weighted_metrics():
+    nb = NumericBaseline()
+    df = pd.DataFrame(
+        {
+            'pipeline_stage': [
+                PipelineStage.WON_CLOSED.value,
+                PipelineStage.LOST.value,
+                PipelineStage.OPEN_ENQUIRY.value,
+            ],
+            'status_category': [
+                StatusCategory.WON.value,
+                StatusCategory.LOST.value,
+                StatusCategory.OPEN.value,
+            ],
+            'date_created': [
+                _recent(30),
+                _recent(800),
+                _recent(400),
+            ],
+        }
+    )
+
+    rate, stats = nb.calculate_conversion_rate(df, method='inclusive')
+
+    assert rate is not None
+    assert stats['wins'] == 1
+    assert stats['wins_weighted'] != pytest.approx(stats['wins'])
+    assert stats['weighting'].startswith('time_weighted')
+
+
+def test_closed_only_preserves_fractional_weights():
+    nb = NumericBaseline()
+    df = pd.DataFrame(
+        {
+            'pipeline_stage': [
+                PipelineStage.WON_CLOSED.value,
+                PipelineStage.LOST.value,
+            ],
+            'status_category': [
+                StatusCategory.WON.value,
+                StatusCategory.LOST.value,
+            ],
+            'date_created': [
+                _recent(15),
+                _recent(900),
+            ],
+        }
+    )
+
+    rate, stats = nb.calculate_conversion_rate(df, method='closed_only')
+
+    assert rate is not None
+    assert stats['wins_weighted'] != pytest.approx(stats['wins'])
+    assert stats['losses_weighted'] != pytest.approx(stats['losses'])
+    assert stats['weighting'].startswith('time_weighted')


### PR DESCRIPTION
## Summary
- add configurable defaults to enable time-weighted numeric baselines
- weight gestation and conversion calculations by recency while preserving existing statistics
- cover recency weighting behaviour with new numeric baseline unit tests

## Testing
- pytest tests/test_numeric_analyzer.py

------
https://chatgpt.com/codex/tasks/task_e_68dd1765b11c8329abcbf728364dfd52